### PR TITLE
Gini Impurity - Empty collection error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # BoostingDeciionTrees.jl
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://MateoSkmn.github.io/BoostingDecisionTrees.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://MateoSkmn.github.io/BoostingDecisionTrees.jl/dev/)
 [![Build Status](https://github.com/MateoSkmn/BoostingDecisionTrees.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/MateoSkmn/BoostingDecisionTrees.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/MateoSkmn/BoostingDecisionTrees.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MateoSkmn/BoostingDecisionTrees.jl)
@@ -17,11 +16,20 @@ julia> using .BoostingDecisionTrees
 
 # Examples
 ### Gini Impurity
-First define your dataset that you want to train on. Please keep in mind that the current implementation only allows a matrix for X
+First define your dataset that you want to train on.
 ```shell
 julia>  X = [1 2; 2 3; 11 21; 12 22]
 
 julia> y = [0, 0, 1, 1]
+
+julia> stump = train_stump(X, y)
+```
+Please keep in mind that the current implementation only allows a matrix for X!
+You can test with just one feature by reshaping a Vector:
+```shell
+julia> x = [1,2,3,4]
+
+julia> X = reshape(x, :, 1)
 
 julia> stump = train_stump(X, y)
 ```

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,5 +1,4 @@
 # BoostingDeciionTrees.jl
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://MateoSkmn.github.io/BoostingDecisionTrees.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://MateoSkmn.github.io/BoostingDecisionTrees.jl/dev/)
 [![Build Status](https://github.com/MateoSkmn/BoostingDecisionTrees.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/MateoSkmn/BoostingDecisionTrees.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/MateoSkmn/BoostingDecisionTrees.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MateoSkmn/BoostingDecisionTrees.jl)
@@ -17,11 +16,20 @@ julia> using .BoostingDecisionTrees
 
 # Examples
 ### Gini Impurity
-First define your dataset that you want to train on. Please keep in mind that the current implementation only allows a matrix for X
+First define your dataset that you want to train on.
 ```shell
 julia>  X = [1 2; 2 3; 11 21; 12 22]
 
 julia> y = [0, 0, 1, 1]
+
+julia> stump = train_stump(X, y)
+```
+Please keep in mind that the current implementation only allows a matrix for X!
+You can test with just one feature by reshaping a Vector:
+```shell
+julia> x = [1,2,3,4]
+
+julia> X = reshape(x, :, 1)
 
 julia> stump = train_stump(X, y)
 ```

--- a/src/gini_impurity.jl
+++ b/src/gini_impurity.jl
@@ -5,6 +5,9 @@ Compute the Gini impurity of a vector of class labels 'classes'.
 """
 function gini_impurity(classes)
     len = length(classes)
+    if len == 0
+        return 0
+    end
     # https://juliastats.org/StatsBase.jl/v0.17/counts.html#StatsBase.countmap 
     # Create a dictionary of the classes (keys) and how often each one appears (values) in the given data
     counts = countmap(classes)

--- a/test/test_gini_impurity.jl
+++ b/test/test_gini_impurity.jl
@@ -18,6 +18,12 @@
     @test threshold3 == nothing
     @test gini3 == Inf
 
+    # gini_impurity is given empty collection
+        # happens if all data lands on one site of the split
+    threshold4, gini4 = best_split([0,0,0,0], [0,0,1,1])
+    @test threshold4 == 0
+    @test gini4 == 0.5 # Everything is on the same branch
+
     @testset "Function errors" begin
         # Empty arrays
         @test_throws ArgumentError best_split([],[])


### PR DESCRIPTION
Having a feature where the threshold would put all values on one side would trigger an error for the other side because it would receive []