### PR TITLE
Single predict - Stump

### DIFF
--- a/src/AdaBoost.jl
+++ b/src/AdaBoost.jl
@@ -187,6 +187,7 @@ end
 A convenience method for predicting the label of a single sample.
 
 ### Arguments
+- `model::AdaBoost`: A trained AdaBoost structure.
 - `X::AbstractVector`: A single sample represented as a vector of features.
 
 ### Returns

--- a/src/DecisionStump.jl
+++ b/src/DecisionStump.jl
@@ -28,7 +28,7 @@ end
 
 
 """
-    DecisionStump
+    DecisionStump(feature, threshold, left_label, right_label)
 
 A simple binary classifier based on a single feature threshold.
 
@@ -151,4 +151,20 @@ function predict_stump(stump::DecisionStump, X::AbstractMatrix)
     end
 
     return preds
+end
+
+"""
+    predict_stump(stump::DecisionStump, X::AbstractVector)
+
+    A convenience method for predicting the label of a single sample.
+
+    ### Arguments
+    - 'stump::DecisionStump': a trained decision stump model
+    - `X::AbstractVector`: A single sample represented as a vector of features.
+
+    ### Returns
+    - The predicted label for the single input sample.
+"""
+function predict_stump(stump::DecisionStump, X::AbstractVector)
+    return predict_stump(stump, reshape(X, 1, :))
 end

--- a/test/test_decision_stump.jl
+++ b/test/test_decision_stump.jl
@@ -28,8 +28,10 @@ end
 
     stump = train_stump(X, y)
     preds = predict_stump(stump, X)
+    pred_single = predict_stump(stump, [1,2])
 
     @test preds == y
+    @test pred_single[1] == 0
 end
 
 @testset "no split possible (1 sample) -> constant stump" begin


### PR DESCRIPTION
Convenience method for easier testing when predicting data (#10 - for now not necessary while training because the data_loader makes it easier to have more data)